### PR TITLE
perf: avoid clearing canvas on each frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,33 +2,36 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <title>Flow Canvas Field</title>
-    <link rel="stylesheet" href="static/style.css">
-    <script defer src="static/flow_field.js"></script>
+  <meta charset="UTF-8">
+  <title>Flow Canvas Field</title>
+  <link rel="stylesheet" href="static/style.css">
+  <script defer src="static/flow_field.js"></script>
 </head>
 
 <body>
-    <canvas id="flowFieldCanvas" width="800" height="800"></canvas>
+  <canvas id="flowFieldCanvas" width="800" height="800"></canvas>
 
-    <div class="controls_panel">
-        <input id="controls_toggle" type="checkbox">
-        <section class="controls_section">
-            <div class="control_row">
-                <label for="stop_animation_toggle">Stop</label>
-                <input id="stop_animation_toggle" type="button" title="Stop Animation" name="stop-animation">
-            </div>
-            <div class="control_row">
-                <label for="reload_animation_toggle">Reload</label>
-                <input id="reload_animation_toggle" type="button" title="Reload Animation" name="reload-animation">
-            </div>
-            <div class="control_row">
-                <label for="shuffle_field_toggle">Shuffle</label>
-                <input id="shuffle_field_toggle" type="button" title="Shuffle Field" name="shuffle-field">
-            </div>
-        </section>
-        <label for="controls_toggle" id="label_controls_toggle">Toggle Controls</label>
-    </div>
+  <div class="controls_panel">
+    <input id="controls_toggle" type="checkbox">
+    <section class="controls_section">
+      <div class="control_row">
+        <span id="cur_field_pattern_name">sinusoidal</span>
+      </div>
+      <div class="control_row">
+        <label for="shuffle_field_toggle">Shuffle</label>
+        <input id="shuffle_field_toggle" type="button" title="Shuffle Field" name="shuffle-field">
+      </div>
+      <div class="control_row">
+        <label for="stop_animation_toggle">Stop</label>
+        <input id="stop_animation_toggle" type="button" title="Stop Animation" name="stop-animation">
+      </div>
+      <div class="control_row">
+        <label for="reload_animation_toggle">Reload</label>
+        <input id="reload_animation_toggle" type="button" title="Reload Animation" name="reload-animation">
+      </div>
+    </section>
+    <label for="controls_toggle" id="label_controls_toggle">Toggle Controls</label>
+  </div>
 </body>
 
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,9 +1,9 @@
 /* static/style.css */
 
 :root {
-    --font-mono: 'Courier New', Courier, monospace;
+    --font-mono: monospace;
     --text-primary: hsl(0, 0%, 100%);
-    --primary: hsl(240, 25%, 27%);
+    --primary: hsl(240deg 33% 9% / 90%);
     --secondary: hsl(240, 39%, 19%);
 
     --spacer: .5em;
@@ -27,6 +27,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     color: var(--text-primary);
     background-color: var(--primary);
+    overflow: hidden;
 }
 
 canvas {
@@ -43,6 +44,7 @@ button {
     box-shadow: none;
     border: 0;
     padding: var(--spacer-sm);
+    cursor: pointer;
 }
 
 
@@ -53,9 +55,10 @@ button {
     background-color: var(--primary, #335);
     opacity: 0.8;
     font-family: var(--font-mono);
-    font-size: small;
-    padding-inline: var(--spacer-sm);
+    /* font-size: small; */
+    /* padding-inline: var(--spacer-sm); */
     box-shadow: var(--shadow);
+    min-width: 22ch;
 }
 
 /* Hide it initially. Toggle it by input with id #controls_toggle */
@@ -81,8 +84,11 @@ input#controls_toggle {
 }
 
 label#label_controls_toggle {
+    display: block;
     color: var(--text-primary);
-    padding: var(--spacer-sm);
+    text-align: center;
+    cursor: pointer;
+    /* padding: var(--spacer-sm); */
 
     &:hover {
         box-shadow: var(--shadow);
@@ -91,11 +97,16 @@ label#label_controls_toggle {
 }
 
 section.controls_section {
-    gap: var(--spacer-sm);
-    padding-block: var(--spacer-sm);
+    gap: var(--spacer);
+    padding-block: var(--spacer);
+    padding-inline: var(--spacer-sm);
 
     & button {
         font-family: var(--font-mono);
+    }
+
+    & input[type="button"] {
+        cursor: pointer;
     }
 }
 


### PR DESCRIPTION
## Why

- **Avoid drawing flow field points ('arrows') on every frame.** This offloads a significant amount of work during rendering.
- **Avoid clearing the canvas on every frame.** This was the most computationally intensive task.
    - However, not clearing the canvas results in traveling particles leaving trails of their past positions. While this can be aesthetically pleasing, it can become chaotic with multiple particles.

## Future

- **Implement the ability to drop particles into the field using mouse click events.**
- **Explore more efficient methods to clear only the areas of the canvas that have recently changed.**