### PR TITLE
feat: colors describe state of field and particle

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     <input id="controls_toggle" type="checkbox">
     <section class="controls_section">
       <div class="control_row">
+        <span id="gui_fps">10fps</span>
+      </div>
+      <div class="control_row">
         <span id="cur_field_pattern_name">sinusoidal</span>
       </div>
       <div class="control_row">


### PR DESCRIPTION
## Why

- Field arrows have varying HSL values based on a vector's length, size, force, etc. The program now uses a double buffering method to draw the initial field and copy it to the main context. This will become more important in later stages.
- Each particle point is tripled with a diagonal displacement of 1 unit. Each instance of the same particle point is colored differently to indicate movement through turns. A sharp left turn draws more of the point color on the left side, achieved by varying alpha values.
- Manhattan distance is used to calculate distance between particle and closest field vector point; instead of `Math.hypot` for performance reasons.

## Future

- Add more controls to the GUI, for customizing field and particle.
- Add mouse support.
- Add orientation support. Either prefer landscape mode, or scale canvas for portrait mode.
- Adjust refreshing, resize for all double buffers.